### PR TITLE
Added SingleShipment variable to items

### DIFF
--- a/lua/sv_player_extension.lua
+++ b/lua/sv_player_extension.lua
@@ -102,9 +102,13 @@ function Player:PS_BuyItem(item_id)
 		return false
 	end
 
-	if ITEM.SingleShipment and ITEM.VerifySingleShipment and not ITEM:VerifySingleShipment(self) then
-		self:PS_Notify('This item can not be bought right now!')
-		return false
+	if ITEM.SingleShipment and ITEM.VerifySingleShipment then -- Is a single shipment and has a func to verify if it's okay to ship right now
+		local verifybool, verifymsg = ITEM:VerifySingleShipment(self)
+		if not verifybool then
+			local msg = verifymsg or 'This item can not be bought right now!' -- If verifymsg wasn't returned we use the default one
+			self:PS_Notify(msg)
+			return false
+		end
 	end
 	
 	self:PS_TakePoints(ITEM.Price)
@@ -113,7 +117,7 @@ function Player:PS_BuyItem(item_id)
 	
 	ITEM:OnBuy(self)
 	
-	if ITEM.SingleShipment then
+	if ITEM.SingleShipment then -- It was a single shipment so we'll ship right away and forget about it
 		ITEM:OnEquip(self)
 		return true
 	end


### PR DESCRIPTION
Allows items that can be bought for a single round.

Usage:

``` lua
ITEM.SingleShipment = true -- When bought this item is given to you only once

function ITEM:VerifySingleShipment(ply) -- Controls whether or not player is allowed to buy the shipment
    if ply:Alive() then return true end
    return false, "You must be alive to buy this item!" -- Custom notifications can be provided as second argument if first one is false
end
```

An example item (single round Deagle for Trouble in Terrorist Town):

``` lua
ITEM.Name = 'Deagle'
ITEM.Price = 150
ITEM.Model = 'models/weapons/w_pist_deagle.mdl'
ITEM.SingleShipment = true

function ITEM:OnEquip(ply, modifications)
  ply:Give("weapon_zm_revolver")
end

function ITEM:VerifySingleShipment(ply)
  local state = ply:Alive() and ply:IsTerror()
  return state, "You are not alive!" -- Message only matters if state is false so we can do this
end
```
