### PR TITLE
Fixed usergroup checking when Evolve is involved. ( Heh. )

### DIFF
--- a/lua/autorun/pointshop.lua
+++ b/lua/autorun/pointshop.lua
@@ -7,11 +7,13 @@ if SERVER then
 	AddCSLuaFile('vgui/DPointShopGivePoints.lua')
 	AddCSLuaFile('sh_pointshop.lua')
 	AddCSLuaFile('sh_config.lua')
+	AddCSLuaFile('sh_player_extension.lua')
 	AddCSLuaFile('cl_player_extension.lua')
 	AddCSLuaFile('cl_pointshop.lua')
 	
 	include('sh_pointshop.lua')
 	include('sh_config.lua')
+	include('sh_player_extension.lua')
 	include('sv_player_extension.lua')
 	include('sv_pointshop.lua')
 end
@@ -24,6 +26,7 @@ if CLIENT then
 	include('vgui/DPointShopGivePoints.lua')
 	include('sh_pointshop.lua')
 	include('sh_config.lua')
+	include('sh_player_extension.lua')
 	include('cl_player_extension.lua')
 	include('cl_pointshop.lua')
 end

--- a/lua/sh_player_extension.lua
+++ b/lua/sh_player_extension.lua
@@ -1,0 +1,10 @@
+local Player = FindMetaTable('Player')
+
+-- Because of the huge variaty of admin mods and their various ways of handling usergroups.
+-- This had to be done..
+function Player:PS_GetUsergroup()
+	if ( self.EV_GetRank ) then return self:EV_GetRank() end
+	-- add for each conflicting admin mod.
+
+	return self:GetNWString( "UserGroup" )
+end

--- a/lua/sv_player_extension.lua
+++ b/lua/sv_player_extension.lua
@@ -164,7 +164,7 @@ function Player:PS_BuyItem(item_id)
 	end
 	
 	if ITEM.AllowedUserGroups and #ITEM.AllowedUserGroups > 0 then
-		if not table.HasValue(ITEM.AllowedUserGroups, self:GetNWString("UserGroup", "user")) then
+		if not table.HasValue(ITEM.AllowedUserGroups, self:PS_GetUsergroup()) then
 			self:PS_Notify('You\'re not in the right group to buy this item!')
 			return false
 		end
@@ -174,7 +174,7 @@ function Player:PS_BuyItem(item_id)
 	local CATEGORY = PS:FindCategoryByName(cat_name)
 	
 	if CATEGORY.AllowedUserGroups and #CATEGORY.AllowedUserGroups > 0 then
-		if not table.HasValue(CATEGORY.AllowedUserGroups, self:GetNWString("UserGroup", "user")) then
+		if not table.HasValue(CATEGORY.AllowedUserGroups, self:PS_GetUsergroup()) then
 			self:PS_Notify('You\'re not in the right group to buy this item!')
 			return false
 		end

--- a/lua/vgui/DPointShopMenu.lua
+++ b/lua/vgui/DPointShopMenu.lua
@@ -48,7 +48,7 @@ function PANEL:Init()
 	-- items
 	for _, CATEGORY in pairs(categories) do
 		if CATEGORY.AllowedUserGroups and #CATEGORY.AllowedUserGroups > 0 then
-			if not table.HasValue(CATEGORY.AllowedUserGroups, LocalPlayer():GetNWString("UserGroup", "user")) then
+			if not table.HasValue(CATEGORY.AllowedUserGroups, LocalPlayer():PS_GetUsergroup()) then
 				continue
 			end
 		end


### PR DESCRIPTION
There was an issue where Evolve doesn't use the standard usergroup
variable which means the usergroup checking was out. Added a simple
method so other conflicting admin mods can be checked against in the
future.
