### PR TITLE
Force ID to lowercase

### DIFF
--- a/lua/sh_pointshop.lua
+++ b/lua/sh_pointshop.lua
@@ -79,7 +79,7 @@ function PS:LoadItems()
 					ITEM = {}
 					
 					ITEM.__index = ITEM
-					ITEM.ID = string.gsub(name, '.lua', '')
+					ITEM.ID = string.gsub(string.lower(name), '.lua', '')
 					ITEM.Category = CATEGORY.Name
 					ITEM.Price = 0
 					


### PR DESCRIPTION
This fixes a bug where items don't work if you have capitals in the filename(no errors either). I believe that AddCSLuaFile somehow converts the filename to lowercase so that server and client get different IDs for the same file.
