### PR TITLE
Modified save behavior and providers

### DIFF
--- a/lua/providers/data.lua
+++ b/lua/providers/data.lua
@@ -25,6 +25,42 @@ function PROVIDER:GetData(ply, callback)
 	return callback(points, items)
 end
 
+function PROVIDER:SetPoints( ply, set_points )
+	self:GetData(ply, function(points, items)
+		self:SetData(ply, set_points, items)
+	end)
+end
+
+function PROVIDER:GivePoints( ply, add_points )
+	self:GetData(ply, function(points, items)
+		self:SetData(ply, points + add_points, items)
+	end)
+end
+
+function PROVIDER:TakePoints( ply, points )
+	self:GivePoints(ply, -points)
+end
+
+function PROVIDER:SaveItem( ply, item_id, data)
+	self:GiveItem(ply, item_id, data)
+end
+
+function PROVIDER:GiveItem( ply, item_id, data)
+	self:GetData(ply, function(points, items)
+		local tmp = table.Copy(ply.PS_Items)
+		tmp[item_id] = data
+		self:SetData(ply, points, tmp)
+	end)
+end
+
+function PROVIDER:TakeItem( ply, item_id )
+	self:GetData(ply, function(points, items)
+		local tmp = table.Copy(ply.PS_Items)
+		tmp[item_id] = nil
+		self:SetData(ply, points, tmp)
+	end)
+end
+
 function PROVIDER:SetData(ply, points, items)
 	if not file.IsDir('pointshop', 'DATA') then
 		file.CreateDir('pointshop')

--- a/lua/providers/pdata.lua
+++ b/lua/providers/pdata.lua
@@ -2,6 +2,34 @@ function PROVIDER:GetData(ply, callback)
 	return callback(ply:GetPData('PS_Points', 0), util.JSONToTable(ply:GetPData('PS_Items', '{}')))
 end
 
+function PROVIDER:SetPoints(ply, set_points)
+	ply:SetPData('PS_Points', set_points)
+end
+
+function PROVIDER:GivePoints(ply, add_points)
+	ply:SetPData('PS_Points', ply:GetPData('PS_Points', 0) + add_points)
+end
+
+function PROVIDER:TakePoints(ply, points)
+	self:GivePoints(ply, -points)
+end
+
+function PROVIDER:SaveItem(ply, item_id, data)
+	self:GiveItem(ply, item_id, data)
+end
+
+function PROVIDER:GiveItem(ply, item_id, data)
+	local tmp = table.Copy(ply.PS_Items)
+	tmp[item_id] = data
+	ply:SetPData('PS_Items', util.TableToJSON(tmp))
+end
+
+function PROVIDER:TakeItem(ply, item_id)
+	local tmp = util.JSONToTable(ply:GetPData('PS_Items', '{}'))
+	tmp[item_id] = nil
+	ply:SetPData('PS_Items', util.TableToJSON(tmp))
+end
+
 function PROVIDER:SetData(ply, points, items)
 	ply:SetPData('PS_Points', points)
 	ply:SetPData('PS_Items', util.TableToJSON(items))

--- a/lua/sv_player_extension.lua
+++ b/lua/sv_player_extension.lua
@@ -84,7 +84,6 @@ function Player:PS_PlayerInitialSpawn()
 end
 
 function Player:PS_PlayerDisconnected()
-	self:PS_Save()
 	PS.ClientsideModels[self] = nil
 	
 	if timer.Exists('PS_PointsOverTime_' .. self:UniqueID()) then
@@ -92,10 +91,7 @@ function Player:PS_PlayerDisconnected()
 	end
 end
 
-function Player:PS_Save()
-	-- Make sure we don't save before we have loaded the data for the first time
-	if not self.PS_FirstLoadCompleted then return end
-	
+function Player:PS_Save()	
 	PS:SetPlayerData(self, self.PS_Points, self.PS_Items)
 end
 
@@ -109,8 +105,6 @@ function Player:PS_LoadData()
 		
 		self:PS_SendPoints()
 		self:PS_SendItems()
-
-		self.PS_FirstLoadCompleted = true
 	end)
 end
 
@@ -131,16 +125,19 @@ end
 
 function Player:PS_GivePoints(points)
 	self.PS_Points = self.PS_Points + points
+	PS:GivePlayerPoints(self, points)
 	self:PS_SendPoints()
 end
 
 function Player:PS_TakePoints(points)
 	self.PS_Points = self.PS_Points - points >= 0 and self.PS_Points - points or 0
+	PS:TakePlayerPoints(self, points)
 	self:PS_SendPoints()
 end
 
 function Player:PS_SetPoints(points)
 	self.PS_Points = points
+	PS:SetPlayerPoints(self, points)
 	self:PS_SendPoints()
 end
 
@@ -156,9 +153,11 @@ end
 
 function Player:PS_GiveItem(item_id)
 	if not PS.Items[item_id] then return false end
-	
+
 	self.PS_Items[item_id] = { Modifiers = {}, Equipped = false }
 	
+	PS:GivePlayerItem(self, item_id, self.PS_Items[item_id])
+
 	self:PS_SendItems()
 	
 	return true
@@ -169,6 +168,8 @@ function Player:PS_TakeItem(item_id)
 	if not self:PS_HasItem(item_id) then return false end
 	
 	self.PS_Items[item_id] = nil
+
+	PS:GivePlayerItem(self, item_id)
 	
 	self:PS_SendItems()
 	
@@ -333,6 +334,8 @@ function Player:PS_EquipItem(item_id)
 	ITEM:OnEquip(self, self.PS_Items[item_id].Modifiers)
 	
 	self:PS_Notify('Equipped ', ITEM.Name, '.')
+
+	PS:SavePlayerItem(self, item_id, self.PS_Items[item_id])
 	
 	self:PS_SendItems()
 end
@@ -360,6 +363,8 @@ function Player:PS_HolsterItem(item_id)
 	ITEM:OnHolster(self)
 	
 	self:PS_Notify('Holstered ', ITEM.Name, '.')
+
+	PS:SavePlayerItem(self, item_id, self.PS_Items[item_id])
 	
 	self:PS_SendItems()
 end
@@ -379,6 +384,8 @@ function Player:PS_ModifyItem(item_id, modifications)
 	end
 	
 	ITEM:OnModify(self, self.PS_Items[item_id].Modifiers)
+
+	PS:SavePlayerItem(self, item_id, self.PS_Items[item_id])
 	
 	self:PS_SendItems()
 end
@@ -422,8 +429,6 @@ end
 -- send stuff
 
 function Player:PS_SendPoints()
-	self:PS_Save()
-	
 	net.Start('PS_Points')
 		net.WriteEntity(self)
 		net.WriteInt(self.PS_Points, 32)
@@ -431,8 +436,6 @@ function Player:PS_SendPoints()
 end
 
 function Player:PS_SendItems()
-	self:PS_Save()
-	
 	net.Start('PS_Items')
 		net.WriteEntity(self)
 		net.WriteTable(self.PS_Items)

--- a/lua/sv_pointshop.lua
+++ b/lua/sv_pointshop.lua
@@ -274,3 +274,69 @@ function PS:SetPlayerData(ply, points, items)
 	
 	provider:SetData(ply, points, items)
 end
+
+function PS:SetPlayerPoints(ply, points)
+	local provider = self.DataProviders[self.Config.DataProvider]
+	
+	if not provider or not self.Config.DataProvider then
+		Error('PointShop: Missing provider. Update ALL files when there is an update.')
+		return
+	end
+	
+	provider:SetPoints(ply, points)
+end
+
+function PS:GivePlayerPoints(ply, points)
+	local provider = self.DataProviders[self.Config.DataProvider]
+	
+	if not provider or not self.Config.DataProvider then
+		Error('PointShop: Missing provider. Update ALL files when there is an update.')
+		return
+	end
+	
+	provider:GivePoints(ply, points, items)
+end
+
+function PS:TakePlayerPoints(ply, points)
+	local provider = self.DataProviders[self.Config.DataProvider]
+	
+	if not provider or not self.Config.DataProvider then
+		Error('PointShop: Missing provider. Update ALL files when there is an update.')
+		return
+	end
+	
+	provider:TakePoints(ply, points)
+end
+
+function PS:SavePlayerItem(ply, item_id, data)
+	local provider = self.DataProviders[self.Config.DataProvider]
+	
+	if not provider or not self.Config.DataProvider then
+		Error('PointShop: Missing provider. Update ALL files when there is an update.')
+		return
+	end
+	
+	provider:SaveItem(ply, item_id, data)
+end
+
+function PS:GivePlayerItem(ply, item_id, data)
+	local provider = self.DataProviders[self.Config.DataProvider]
+	
+	if not provider or not self.Config.DataProvider then
+		Error('PointShop: Missing provider. Update ALL files when there is an update.')
+		return
+	end
+	
+	provider:GiveItem(ply, item_id, data)
+end
+
+function PS:TakePlayerItem(ply, item_id)
+	local provider = self.DataProviders[self.Config.DataProvider]
+	
+	if not provider or not self.Config.DataProvider then
+		Error('PointShop: Missing provider. Update ALL files when there is an update.')
+		return
+	end
+	
+	provider:TakeItem(ply, item_id)
+end


### PR DESCRIPTION
This pull request makes pointshop save only when points and items are changed.
Provider functions has also been added to allow more advanced providers, such as a mysql provider which has each item on a separate row.
Points can also be edited at the source and not be overwritten and will increment or decrement as expected.
