### PR TITLE
Check Player.Spectating variable before equipping items, fixes #188

### DIFF
--- a/lua/pointshop/sv_player_extension.lua
+++ b/lua/pointshop/sv_player_extension.lua
@@ -2,11 +2,15 @@ local Player = FindMetaTable('Player')
 
 function Player:PS_PlayerSpawn()
 	if not self:PS_CanPerformAction() then return end
-	
+
 	-- TTT ( and others ) Fix
 	if TEAM_SPECTATOR != nil and self:Team() == TEAM_SPECTATOR then return end
 	if TEAM_SPEC != nil and self:Team() == TEAM_SPEC then return end
-	
+
+	-- Murder Spectator Fix (they don't specify the above enums when making teams)
+	-- https://github.com/mechanicalmind/murder/blob/master/gamemode/sv_spectate.lua#L15
+	if self.Spectating then return end
+
 	timer.Simple(1, function()
 		if !IsValid(self) then return end
 		for item_id, item in pairs(self.PS_Items) do
@@ -30,15 +34,15 @@ end
 function Player:PS_PlayerInitialSpawn()
 	self.PS_Points = 0
 	self.PS_Items = {}
-	
+
 	-- Send stuff
 	timer.Simple(1, function()
 		if !IsValid(self) then return end
-		
+
 		self:PS_LoadData()
 		self:PS_SendClientsideModels()
 	end)
-	
+
 	if PS.Config.NotifyOnJoin then
 		if PS.Config.ShopKey ~= '' then
 			timer.Simple(5, function() -- Give them time to load up
@@ -46,21 +50,21 @@ function Player:PS_PlayerInitialSpawn()
 				self:PS_Notify('Press ' .. PS.Config.ShopKey .. ' to open PointShop!')
 			end)
 		end
-		
+
 		if PS.Config.ShopCommand ~= '' then
 			timer.Simple(5, function() -- Give them time to load up
 				if !IsValid(self) then return end
 				self:PS_Notify('Type ' .. PS.Config.ShopCommand .. ' in console to open PointShop!')
 			end)
 		end
-		
+
 		if PS.Config.ShopChatCommand ~= '' then
 			timer.Simple(5, function() -- Give them time to load up
 				if !IsValid(self) then return end
 				self:PS_Notify('Type ' .. PS.Config.ShopChatCommand .. ' in chat to open PointShop!')
 			end)
 		end
-		
+
 		timer.Simple(10, function() -- Give them time to load up
 			if !IsValid(self) then return end
 			self:PS_Notify('You have ' .. self:PS_GetPoints() .. ' ' .. PS.Config.PointsName .. ' to spend!')
@@ -73,7 +77,7 @@ function Player:PS_PlayerInitialSpawn()
 			self:PS_Notify("PointShop is out of date, please tell the server owner!")
 		end)
 	end
-	
+
 	if PS.Config.PointsOverTime then
 		timer.Create('PS_PointsOverTime_' .. self:UniqueID(), PS.Config.PointsOverTimeDelay * 60, 0, function()
 			if !IsValid(self) then return end
@@ -85,7 +89,7 @@ end
 
 function Player:PS_PlayerDisconnected()
 	PS.ClientsideModels[self] = nil
-	
+
 	if timer.Exists('PS_PointsOverTime_' .. self:UniqueID()) then
 		timer.Destroy('PS_PointsOverTime_' .. self:UniqueID())
 	end
@@ -98,11 +102,11 @@ end
 function Player:PS_LoadData()
 	self.PS_Points = 0
 	self.PS_Items = {}
-	
+
 	PS:GetPlayerData(self, function(points, items)
 		self.PS_Points = points
 		self.PS_Items = items
-		
+
 		self:PS_SendPoints()
 		self:PS_SendItems()
 	end)
@@ -115,12 +119,12 @@ function Player:PS_CanPerformAction(itemname)
 
 	if (self.IsSpec and self:IsSpec()) and not itemexcept then allowed = false end
 	if not self:Alive() and not itemexcept then allowed = false end
-	
-	
+
+
 	if not allowed then
 		self:PS_Notify('You\'re not allowed to do that at the moment!')
 	end
-	
+
 	return allowed
 end
 
@@ -156,26 +160,26 @@ end
 
 function Player:PS_GiveItem(item_id)
 	if not PS.Items[item_id] then return false end
-	
+
 	self.PS_Items[item_id] = { Modifiers = {}, Equipped = false }
 
 	PS:GivePlayerItem(self, item_id, self.PS_Items[item_id])
-	
+
 	self:PS_SendItems()
-	
+
 	return true
 end
 
 function Player:PS_TakeItem(item_id)
 	if not PS.Items[item_id] then return false end
 	if not self:PS_HasItem(item_id) then return false end
-	
+
 	self.PS_Items[item_id] = nil
 
 	PS:TakePlayerItem(self, item_id)
-	
+
 	self:PS_SendItems()
-	
+
 	return true
 end
 
@@ -184,41 +188,41 @@ end
 function Player:PS_BuyItem(item_id)
 	local ITEM = PS.Items[item_id]
 	if not ITEM then return false end
-	
+
 	local points = PS.Config.CalculateBuyPrice(self, ITEM)
-	
+
 	if not self:PS_HasPoints(points) then return false end
 	if not self:PS_CanPerformAction(item_id) then return end
-	
+
 	if ITEM.AdminOnly and not self:IsAdmin() then
 		self:PS_Notify('This item is Admin only!')
 		return false
 	end
-	
+
 	if ITEM.AllowedUserGroups and #ITEM.AllowedUserGroups > 0 then
 		if not table.HasValue(ITEM.AllowedUserGroups, self:PS_GetUsergroup()) then
 			self:PS_Notify('You\'re not in the right group to buy this item!')
 			return false
 		end
 	end
-	
+
 	local cat_name = ITEM.Category
 	local CATEGORY = PS:FindCategoryByName(cat_name)
-	
+
 	if CATEGORY.AllowedUserGroups and #CATEGORY.AllowedUserGroups > 0 then
 		if not table.HasValue(CATEGORY.AllowedUserGroups, self:PS_GetUsergroup()) then
 			self:PS_Notify('You\'re not in the right group to buy this item!')
 			return false
 		end
 	end
-	
+
 	if CATEGORY.CanPlayerSee then
 		if not CATEGORY:CanPlayerSee(self) then
 			self:PS_Notify('You\'re not allowed to buy this item!')
 			return false
 		end
 	end
-	
+
 	if ITEM.CanPlayerBuy then -- should exist but we'll check anyway
 		local allowed, message
 		if ( type(ITEM.CanPlayerBuy) == "function" ) then
@@ -226,19 +230,19 @@ function Player:PS_BuyItem(item_id)
 		elseif ( type(ITEM.CanPlayerBuy) == "boolean" ) then
 			allowed = ITEM.CanPlayerBuy
 		end
-		
+
 		if not allowed then
 			self:PS_Notify(message or 'You\'re not allowed to buy this item!')
 			return false
 		end
 	end
-	
+
 	self:PS_TakePoints(points)
-	
+
 	self:PS_Notify('Bought ', ITEM.Name, ' for ', points, ' ', PS.Config.PointsName)
-	
+
 	ITEM:OnBuy(self)
-	
+
 	if ITEM.SingleUse then
 		self:PS_Notify('Single use item. You\'ll have to buy this item again next time!')
 		return
@@ -251,9 +255,9 @@ end
 function Player:PS_SellItem(item_id)
 	if not PS.Items[item_id] then return false end
 	if not self:PS_HasItem(item_id) then return false end
-	
+
 	local ITEM = PS.Items[item_id]
-	
+
 	if ITEM.CanPlayerSell then -- should exist but we'll check anyway
 		local allowed, message
 		if ( type(ITEM.CanPlayerSell) == "function" ) then
@@ -261,7 +265,7 @@ function Player:PS_SellItem(item_id)
 		elseif ( type(ITEM.CanPlayerSell) == "boolean" ) then
 			allowed = ITEM.CanPlayerSell
 		end
-		
+
 		if not allowed then
 			self:PS_Notify(message or 'You\'re not allowed to sell this item!')
 			return false
@@ -270,12 +274,12 @@ function Player:PS_SellItem(item_id)
 
 	local points = PS.Config.CalculateSellPrice(self, ITEM)
 	self:PS_GivePoints(points)
-	
+
 	ITEM:OnHolster(self)
 	ITEM:OnSell(self)
-	
+
 	self:PS_Notify('Sold ', ITEM.Name, ' for ', points, ' ', PS.Config.PointsName)
-	
+
 	return self:PS_TakeItem(item_id)
 end
 
@@ -285,20 +289,20 @@ end
 
 function Player:PS_HasItemEquipped(item_id)
 	if not self:PS_HasItem(item_id) then return false end
-	
+
 	return self.PS_Items[item_id].Equipped or false
 end
 
 function Player:PS_NumItemsEquippedFromCategory(cat_name)
 	local count = 0
-	
+
 	for item_id, item in pairs(self.PS_Items) do
 		local ITEM = PS.Items[item_id]
 		if ITEM.Category == cat_name and item.Equipped then
 			count = count + 1
 		end
 	end
-	
+
 	return count
 end
 
@@ -308,30 +312,30 @@ function Player:PS_EquipItem(item_id)
 	if not PS.Items[item_id] then return false end
 	if not self:PS_HasItem(item_id) then return false end
 	if not self:PS_CanPerformAction(item_id) then return false end
-	
+
 	local ITEM = PS.Items[item_id]
-	
+
 	if type(ITEM.CanPlayerEquip) == 'function' then
 		allowed, message = ITEM:CanPlayerEquip(self)
 	elseif type(ITEM.CanPlayerEquip) == 'boolean' then
 		allowed = ITEM.CanPlayerEquip
 	end
-	
+
 	if not allowed then
 		self:PS_Notify(message or 'You\'re not allowed to equip this item!')
 		return false
 	end
-	
+
 	local cat_name = ITEM.Category
 	local CATEGORY = PS:FindCategoryByName(cat_name)
-	
+
 	if CATEGORY and CATEGORY.AllowedEquipped > -1 then
 		if self:PS_NumItemsEquippedFromCategory(cat_name) + 1 > CATEGORY.AllowedEquipped then
 			self:PS_Notify('Only ' .. CATEGORY.AllowedEquipped .. ' item' .. (CATEGORY.AllowedEquipped == 1 and '' or 's') .. ' can be equipped from this category!')
 			return false
 		end
 	end
-	
+
 	if CATEGORY.SharedCategories then
 		local ConCatCats = CATEGORY.Name
 		for p, c in pairs( CATEGORY.SharedCategories ) do
@@ -363,15 +367,15 @@ function Player:PS_EquipItem(item_id)
 			end
 		end
 	end
-	
+
 	self.PS_Items[item_id].Equipped = true
-	
+
 	ITEM:OnEquip(self, self.PS_Items[item_id].Modifiers)
-	
+
 	self:PS_Notify('Equipped ', ITEM.Name, '.')
 
 	PS:SavePlayerItem(self, item_id, self.PS_Items[item_id])
-	
+
 	self:PS_SendItems()
 end
 
@@ -379,28 +383,28 @@ function Player:PS_HolsterItem(item_id)
 	if not PS.Items[item_id] then return false end
 	if not self:PS_HasItem(item_id) then return false end
 	if not self:PS_CanPerformAction(item_id) then return false end
-	
+
 	self.PS_Items[item_id].Equipped = false
-	
+
 	local ITEM = PS.Items[item_id]
-	
+
 	if type(ITEM.CanPlayerHolster) == 'function' then
 		allowed, message = ITEM:CanPlayerHolster(self)
 	elseif type(ITEM.CanPlayerHolster) == 'boolean' then
 		allowed = ITEM.CanPlayerHolster
 	end
-	
+
 	if not allowed then
 		self:PS_Notify(message or 'You\'re not allowed to holster this item!')
 		return false
 	end
-	
+
 	ITEM:OnHolster(self)
-	
+
 	self:PS_Notify('Holstered ', ITEM.Name, '.')
 
 	PS:SavePlayerItem(self, item_id, self.PS_Items[item_id])
-	
+
 	self:PS_SendItems()
 end
 
@@ -411,17 +415,17 @@ function Player:PS_ModifyItem(item_id, modifications)
 	if not self:PS_HasItem(item_id) then return false end
 	if not type(modifications) == "table" then return false end
 	if not self:PS_CanPerformAction(item_id) then return false end
-	
+
 	local ITEM = PS.Items[item_id]
-	
+
 	for key, value in pairs(modifications) do
 		self.PS_Items[item_id].Modifiers[key] = value
 	end
-	
+
 	ITEM:OnModify(self, self.PS_Items[item_id].Modifiers)
 
 	PS:SavePlayerItem(self, item_id, self.PS_Items[item_id])
-	
+
 	self:PS_SendItems()
 end
 
@@ -430,14 +434,14 @@ end
 function Player:PS_AddClientsideModel(item_id)
 	if not PS.Items[item_id] then return false end
 	if not self:PS_HasItem(item_id) then return false end
-	
+
 	net.Start('PS_AddClientsideModel')
 		net.WriteEntity(self)
 		net.WriteString(item_id)
 	net.Broadcast()
-	
+
 	if not PS.ClientsideModels[self] then PS.ClientsideModels[self] = {} end
-	
+
 	PS.ClientsideModels[self][item_id] = item_id
 end
 
@@ -445,12 +449,12 @@ function Player:PS_RemoveClientsideModel(item_id)
 	if not PS.Items[item_id] then return false end
 	if not self:PS_HasItem(item_id) then return false end
 	if not PS.ClientsideModels[self] or not PS.ClientsideModels[self][item_id] then return false end
-	
+
 	net.Start('PS_RemoveClientsideModel')
 		net.WriteEntity(self)
 		net.WriteString(item_id)
 	net.Broadcast()
-	
+
 	PS.ClientsideModels[self][item_id] = nil
 end
 
@@ -477,7 +481,7 @@ function Player:PS_SendItems()
 	net.Broadcast()
 end
 
-function Player:PS_SendClientsideModels()	
+function Player:PS_SendClientsideModels()
 	net.Start('PS_SendClientsideModels')
 		net.WriteTable(PS.ClientsideModels)
 	net.Send(self)


### PR DESCRIPTION
Murder doesn't specify TEAM_SPEC or TEAM_SPECTATOR enums, but they do specify Player.Spectating variable.