### PR TITLE
Added support for ITEM.Slot

### DIFF
--- a/lua/pointshop/sv_player_extension.lua
+++ b/lua/pointshop/sv_player_extension.lua
@@ -336,6 +336,16 @@ function Player:PS_EquipItem(item_id)
 		end
 	end
 
+	if PS.Items[item_id].Slot then
+		for id, item in pairs(self.PS_Items) do
+			if item_id != id and PS.Items[id].Slot and PS.Items[id].Slot == PS.Items[item_id].Slot then
+				self:PS_HolsterItem(id)
+				continue
+			end
+		end
+	end
+
+
 	if CATEGORY.SharedCategories then
 		local ConCatCats = CATEGORY.Name
 		for p, c in pairs( CATEGORY.SharedCategories ) do

--- a/lua/pointshop/sv_player_extension.lua
+++ b/lua/pointshop/sv_player_extension.lua
@@ -340,7 +340,6 @@ function Player:PS_EquipItem(item_id)
 		for id, item in pairs(self.PS_Items) do
 			if item_id != id and PS.Items[id].Slot and PS.Items[id].Slot == PS.Items[item_id].Slot then
 				self:PS_HolsterItem(id)
-				continue
 			end
 		end
 	end

--- a/lua/pointshop/sv_player_extension.lua
+++ b/lua/pointshop/sv_player_extension.lua
@@ -338,7 +338,7 @@ function Player:PS_EquipItem(item_id)
 
 	if PS.Items[item_id].Slot then
 		for id, item in pairs(self.PS_Items) do
-			if item_id != id and PS.Items[id].Slot and PS.Items[id].Slot == PS.Items[item_id].Slot then
+			if item_id != id and PS.Items[id].Slot and PS.Items[id].Slot == PS.Items[item_id].Slot and self.PS_Items[id].Equipped then
 				self:PS_HolsterItem(id)
 			end
 		end


### PR DESCRIPTION
Allows an item to have a variable set for ITEM.Slot.
If an Item is equipped with the same variable set for Slot, it well automatically be unequipped.
I added this because I needed it for something I was doing in pointshop and was really confused as to why it wasn't a thing already. Might as well add it here.