### PR TITLE
Remove long text.

### DIFF
--- a/lua/pointshop/items/headshatsmasks/texthat.lua
+++ b/lua/pointshop/items/headshatsmasks/texthat.lua
@@ -24,7 +24,13 @@ end
 
 function ITEM:Modify(modifications)
 	Derma_StringRequest("Text", "What text do you want your hat to say?", "", function(text)
+		
+		if string.find(text, "#") then
+			text = string.gsub(text, "#", "")
+		end
+		
 		modifications.text = string.sub(text, 1, MaxTextLength)
 		PS:ShowColorChooser(self, modifications)
 	end)
 end
+


### PR DESCRIPTION
There's probably an easier/better way of fixing this, but it stops the valve VAC ban text, as seen here: http://i.imgur.com/4pIEz3y.jpg