### PR TITLE
Optimize item loading with a delay

### DIFF
--- a/lua/pointshop/vgui/DPointShopMenu.lua
+++ b/lua/pointshop/vgui/DPointShopMenu.lua
@@ -247,8 +247,8 @@ function PANEL:Init()
 		
 		DScrollPanel:AddItem(ShopCategoryTabLayout)
 		
-		-- Create 50ms delay between loading each pointshop item
-		-- This reduces hitching and loading times
+		-- Create 50ms delay before loading the first item 
+		-- Then a 15ms delay between loading each concurrent item
 		local delay = 0.05		
 		for _, ITEM in pairs(items) do				
 			if ITEM.Category == CATEGORY.Name then			
@@ -259,7 +259,7 @@ function PANEL:Init()
 					
 					ShopCategoryTabLayout:Add(model)				
 				end)					
-				delay = delay + 0.05
+				delay = delay + 0.015
 			end
 		end
 

--- a/lua/pointshop/vgui/DPointShopMenu.lua
+++ b/lua/pointshop/vgui/DPointShopMenu.lua
@@ -247,13 +247,19 @@ function PANEL:Init()
 		
 		DScrollPanel:AddItem(ShopCategoryTabLayout)
 		
-		for _, ITEM in pairs(items) do
-			if ITEM.Category == CATEGORY.Name then
-				local model = vgui.Create('DPointShopItem')
-				model:SetData(ITEM)
-				model:SetSize(128, 128)
-				
-				ShopCategoryTabLayout:Add(model)
+		-- Create 50ms delay between loading each pointshop item
+		-- This reduces hitching and loading times
+		local delay = 0.05		
+		for _, ITEM in pairs(items) do				
+			if ITEM.Category == CATEGORY.Name then			
+				timer.Simple(delay, function()
+					local model = vgui.Create('DPointShopItem')
+					model:SetData(ITEM)
+					model:SetSize(128, 128)
+					
+					ShopCategoryTabLayout:Add(model)				
+				end)					
+				delay = delay + 0.05
 			end
 		end
 


### PR DESCRIPTION
With an approximation of over 150 items in the pointshop, the Garry's Mod game client will start hitching, because too many 'DPointShopItem' objects are being created at once. This optimization creates a 50ms delay, between creating each 'DPointShopItem' object. It allows the rest of the GUI to continue loading before all the items have completed. Hitching is reduced by approximately 80% and loading times are also reduced. This should theoretically triple the number of possible items, without an extended freeze period.