### PR TITLE
Fix for issue with trails not being removed on death

### DIFF
--- a/lua/pointshop/items/trails/electric.lua
+++ b/lua/pointshop/items/trails/electric.lua
@@ -3,7 +3,9 @@ ITEM.Price = 150
 ITEM.Material = 'trails/electric.vmt'
 
 function ITEM:OnEquip(ply, modifications)
-	ply.ElectricTrail = util.SpriteTrail(ply, 0, modifications.color, false, 15, 1, 4, 0.125, self.Material)
+	if !IsValid(ply.ElectricTrail) then
+		ply.ElectricTrail = util.SpriteTrail(ply, 0, modifications.color, false, 15, 1, 4, 0.125, self.Material)
+	end
 end
 
 function ITEM:OnHolster(ply)

--- a/lua/pointshop/items/trails/laser.lua
+++ b/lua/pointshop/items/trails/laser.lua
@@ -3,7 +3,9 @@ ITEM.Price = 150
 ITEM.Material = 'trails/laser.vmt'
 
 function ITEM:OnEquip(ply, modifications)
-	ply.LaserTrail = util.SpriteTrail(ply, 0, modifications.color, false, 15, 1, 4, 0.125, self.Material)
+	if !IsValid(ply.LaserTrail) then
+		ply.LaserTrail = util.SpriteTrail(ply, 0, modifications.color, false, 15, 1, 4, 0.125, self.Material)
+	end
 end
 
 function ITEM:OnHolster(ply)

--- a/lua/pointshop/items/trails/loltrail.lua
+++ b/lua/pointshop/items/trails/loltrail.lua
@@ -3,7 +3,9 @@ ITEM.Price = 150
 ITEM.Material = 'trails/lol.vmt'
 
 function ITEM:OnEquip(ply, modifications)
-	ply.LolTrail = util.SpriteTrail(ply, 0, modifications.color, false, 15, 1, 4, 0.125, self.Material)
+	if !IsValid(ply.LolTrail) then
+		ply.LolTrail = util.SpriteTrail(ply, 0, modifications.color, false, 15, 1, 4, 0.125, self.Material)
+	end
 end
 
 function ITEM:OnHolster(ply)

--- a/lua/pointshop/items/trails/lovetrail.lua
+++ b/lua/pointshop/items/trails/lovetrail.lua
@@ -3,7 +3,9 @@ ITEM.Price = 150
 ITEM.Material = 'trails/love.vmt'
 
 function ITEM:OnEquip(ply, modifications)
-	ply.LoveTrail = util.SpriteTrail(ply, 0, modifications.color, false, 15, 1, 4, 0.125, self.Material)
+	if !IsValid(ply.LoveTrail) then
+		ply.LoveTrail = util.SpriteTrail(ply, 0, modifications.color, false, 15, 1, 4, 0.125, self.Material)
+	end
 end
 
 function ITEM:OnHolster(ply)

--- a/lua/pointshop/items/trails/plasmatrail.lua
+++ b/lua/pointshop/items/trails/plasmatrail.lua
@@ -3,7 +3,9 @@ ITEM.Price = 150
 ITEM.Material = 'trails/plasma.vmt'
 
 function ITEM:OnEquip(ply, modifications)
-	ply.PlasmaTrail = util.SpriteTrail(ply, 0, modifications.color, false, 15, 1, 4, 0.125, self.Material)
+	if !IsValid(ply.PlasmaTrail) then
+		ply.PlasmaTrail = util.SpriteTrail(ply, 0, modifications.color, false, 15, 1, 4, 0.125, self.Material)
+	end
 end
 
 function ITEM:OnHolster(ply)

--- a/lua/pointshop/items/trails/smoke.lua
+++ b/lua/pointshop/items/trails/smoke.lua
@@ -3,7 +3,9 @@ ITEM.Price = 150
 ITEM.Material = 'trails/smoke.vmt'
 
 function ITEM:OnEquip(ply, modifications)
-	ply.SmokeTrail = util.SpriteTrail(ply, 0, modifications.color, false, 15, 1, 4, 0.125, self.Material)
+	if !IsValid(ply.SmokeTrail) then
+		ply.SmokeTrail = util.SpriteTrail(ply, 0, modifications.color, false, 15, 1, 4, 0.125, self.Material)
+	end
 end
 
 function ITEM:OnHolster(ply)

--- a/lua/pointshop/items/trails/tube.lua
+++ b/lua/pointshop/items/trails/tube.lua
@@ -3,7 +3,9 @@ ITEM.Price = 150
 ITEM.Material = 'trails/tube.vmt'
 
 function ITEM:OnEquip(ply, modifications)
-	ply.TubeTrail = util.SpriteTrail(ply, 0, modifications.color, false, 15, 1, 4, 0.125, self.Material)
+	if !IsValid(ply.TubeTrail) then
+		ply.TubeTrail = util.SpriteTrail(ply, 0, modifications.color, false, 15, 1, 4, 0.125, self.Material)
+	end
 end
 
 function ITEM:OnHolster(ply)


### PR DESCRIPTION
Many users (including me) have had an issue with trails not being removed on player death for years (i.e.  #22 ). I found that this was caused when the OnEquip hook was called more than once without the trail being destroyed. So I added an IsValid check to all of the trails to ensure that this does not happen.