### PR TITLE
Add local sqlite as data provider option

### DIFF
--- a/lua/pointshop/providers/sqlite.lua
+++ b/lua/pointshop/providers/sqlite.lua
@@ -1,0 +1,85 @@
+sql.Query("CREATE TABLE IF NOT EXISTS `pointshop_data` ( `sid64` STRING, `points` REAL, `medals` REAL, `items` STRING, PRIMARY KEY(sid64) )")
+
+function PROVIDER:GetData(ply, callback)
+    local query = "SELECT * FROM `pointshop_data` WHERE sid64 = '"..ply:SteamID64().."'"
+
+    local data = ExecuteQueryWithDebug(query)
+
+    if data ~= false and data ~= nil and #data > 0 then
+        local row = data[1]
+        
+        local points = row.points or 0
+        local medals = row.medals or 0
+        local items = util.JSONToTable(row.items or '{}')
+ 
+        callback(points, medals, items)
+    else
+        callback(0, 0, {})
+    end
+end
+
+function PROVIDER:SetMedals(ply, medals)
+    local query = "INSERT OR IGNORE INTO `pointshop_data` (sid64, points, medals, items) VALUES ('"..ply:SteamID64().."', '0', '"..(medals or 0).."', '[]'); UPDATE `pointshop_data` SET medals = "..(medals or 0).." WHERE sid64 = '"..ply:SteamID64().."'"
+    ExecuteQueryWithDebug(query)
+end
+
+function PROVIDER:GiveMedals(ply, medals)
+    local query = "INSERT OR IGNORE INTO `pointshop_data` (sid64, points, medals, items) VALUES ('"..ply:SteamID64().."', '0', '"..(medals or 0).."', '[]'); UPDATE `pointshop_data` SET medals = medals + "..(medals or 0).." WHERE sid64 = '"..ply:SteamID64().."'"
+    ExecuteQueryWithDebug(query)
+end
+
+function PROVIDER:TakeMedals(ply, medals)
+    local query = "INSERT OR IGNORE INTO `pointshop_data` (sid64, points, medals, items) VALUES ('"..ply:SteamID64().."', '0', '"..(medals or 0).."', '[]'); UPDATE `pointshop_data` SET medals = medals - "..(medals or 0).." WHERE sid64 = '"..ply:SteamID64().."'"
+    ExecuteQueryWithDebug(query)
+end
+
+function PROVIDER:SetPoints(ply, points)
+    local query = "INSERT OR IGNORE INTO `pointshop_data` (sid64, points, medals, items) VALUES ('"..ply:SteamID64().."', '"..(points or 0).."', '0', '[]'); UPDATE `pointshop_data` SET points = "..(points or 0).." WHERE sid64 = '"..ply:SteamID64().."'"
+    ExecuteQueryWithDebug(query)
+end
+
+function PROVIDER:GivePoints(ply, points)
+    local query = "INSERT OR IGNORE INTO `pointshop_data` (sid64, points, medals, items) VALUES ('"..ply:SteamID64().."', '"..(points or 0).."', '0', '[]'); UPDATE `pointshop_data` SET points = points + "..(points or 0).." WHERE sid64 = '"..ply:SteamID64().."'"
+    ExecuteQueryWithDebug(query)
+end
+
+function PROVIDER:TakePoints(ply, points)
+    local query = "INSERT OR IGNORE INTO `pointshop_data` (sid64, points, medals, items) VALUES ('"..ply:SteamID64().."', '"..(points or 0).."', '0', '[]'); UPDATE `pointshop_data` SET points = points - "..(points or 0).." WHERE sid64 = '"..ply:SteamID64().."'"
+    ExecuteQueryWithDebug(query)
+end
+
+function PROVIDER:SaveItem(ply, item_id, data)
+    self:GiveItem(ply, item_id, data)
+end
+
+function PROVIDER:GiveItem(ply, item_id, data)
+    local tmp = table.Copy(ply.PS_Items)
+    tmp[item_id] = data
+
+    local query = "INSERT OR IGNORE INTO `pointshop_data` (sid64, points, medals, items) VALUES ('"..ply:SteamID64().."', '0', '0', "..sql.SQLStr(util.TableToJSON(tmp)).."); UPDATE `pointshop_data` SET items = "..sql.SQLStr(util.TableToJSON(tmp)).." WHERE sid64 = '"..ply:SteamID64().."'"
+    ExecuteQueryWithDebug(query)
+end
+
+function PROVIDER:TakeItem(ply, item_id)
+    local tmp = table.Copy(ply.PS_Items)
+    tmp[item_id] = nil
+
+    local query = "INSERT OR IGNORE INTO `pointshop_data` (sid64, points, medals, items) VALUES ('"..ply:SteamID64().."', '0', '0', "..sql.SQLStr(util.TableToJSON(tmp)).."); UPDATE `pointshop_data` SET items = "..sql.SQLStr(util.TableToJSON(tmp)).." WHERE sid64 = '"..ply:SteamID64().."'"
+    ExecuteQueryWithDebug(query)
+end
+ 
+function PROVIDER:SetData(ply, points, medals, items)
+    local query = "INSERT OR IGNORE INTO `pointshop_data` (sid64, points, medals, items) VALUES ('"..ply:SteamID64().."', '"..(points or 0).."', "..(medals or 0)..", "..sql.SQLStr(util.TableToJSON(items)).."); UPDATE `pointshop_data` SET points = "..(points or 0)..", items = "..sql.SQLStr(util.TableToJSON(items)).." WHERE sid64 = '"..ply:SteamID64().."'"
+    ExecuteQueryWithDebug(query)
+end
+
+function ExecuteQueryWithDebug(query)
+    local queryReturn = sql.Query(query)
+    if queryReturn == false then
+        print("SQLITE ERROR!")
+        print("QUERY --> '"..query.."'")
+        print("ERROR --> '"..sql.LastError().."'")
+        debug.Trace()
+    end
+    return queryReturn
+end

--- a/lua/pointshop/providers/sqlite.lua
+++ b/lua/pointshop/providers/sqlite.lua
@@ -1,5 +1,5 @@
 local function QueryWithInsertOrIgnore(ply, query, ...)
-    local insertOrIgnoreStatement = [[INSERT OR IGNORE INTO `pointshop_data` VALUES ('%s', '0', '0', '[]');]]..query
+    local insertOrIgnoreStatement = [[INSERT OR IGNORE INTO `pointshop_data` VALUES ('%s', '0', '[]');]]..query
     local query = string.format(insertOrIgnoreStatement, ply:SteamID64(), ...)
     return sql.Query(query)
 end
@@ -45,7 +45,7 @@ function PROVIDER:GiveItem(ply, item_id, data)
     local tmp = table.Copy(ply.PS_Items)
     tmp[item_id] = data
 
-    local query = [[UPDATE `pointshop_data` SET items = '%s' WHERE sid64 = '%s']]
+    local query = [[UPDATE `pointshop_data` SET items = %s WHERE sid64 = '%s']]
     QueryWithInsertOrIgnore(ply, query, sql.SQLStr(util.TableToJSON(tmp)), ply:SteamID64())
 end
 
@@ -53,11 +53,11 @@ function PROVIDER:TakeItem(ply, item_id)
     local tmp = table.Copy(ply.PS_Items)
     tmp[item_id] = nil
 
-    local query = [[UPDATE `pointshop_data` SET items = '%s' WHERE sid64 = '%s']]
+    local query = [[UPDATE `pointshop_data` SET items = %s WHERE sid64 = '%s']]
     QueryWithInsertOrIgnore(ply, query, sql.SQLStr(util.TableToJSON(tmp)), ply:SteamID64())
 end
  
 function PROVIDER:SetData(ply, points, items)
-    local query = [[UPDATE `pointshop_data` SET points = '%s', items = '%s' WHERE sid64 = '%s']]
+    local query = [[UPDATE `pointshop_data` SET points = '%s', items = %s WHERE sid64 = '%s']]
     QueryWithInsertOrIgnore(ply, query, points, sql.SQLStr(util.TableToJSON(items)), ply:SteamID64())
 end


### PR DESCRIPTION
SQLite it's the preferred and fastest method of storing large amounts of data. 🥇 

**Today we have the pdata storage option, which stores in local gmod sqlite too, why use your option?**
It can be useful for create custom queries or relatories. 👍 

Please ignore my first commit, I had sent the wrong file. 😆 
I'm not fluent in English, sorry.