### PR TITLE
Various additions to PointShop items

### DIFF
--- a/lua/pointshop/cl_init.lua
+++ b/lua/pointshop/cl_init.lua
@@ -65,6 +65,16 @@ function PS:ShowColorChooser(item, modifications)
 		self:SendModifications(item.ID, modifications)
 	end
 end
+function PS:ShowPlyColorChooser(item, modifications)
+	-- TODO: Do this
+	local chooser = vgui.Create('DPointShopColorChooser')
+	chooser:SetColor(modifications.plycolor)
+	
+	chooser.OnChoose = function(color)
+		modifications.plycolor = color
+		self:SendModifications(item.ID, modifications)
+	end
+end
 
 function PS:SendModifications(item_id, modifications)
 	net.Start('PS_ModifyItem')

--- a/lua/pointshop/items/weapons/357.lua
+++ b/lua/pointshop/items/weapons/357.lua
@@ -5,7 +5,11 @@ ITEM.WeaponClass = 'weapon_357'
 ITEM.SingleUse = true
 
 function ITEM:OnBuy(ply)
+    if (!ply:HasWeapon(self.WeaponClass)) then
 	ply:Give(self.WeaponClass)
+    else
+        ply:GiveAmmo(6, "357", false)
+    end
 	ply:SelectWeapon(self.WeaponClass)
 end
 

--- a/lua/pointshop/items/weapons/ar2.lua
+++ b/lua/pointshop/items/weapons/ar2.lua
@@ -5,7 +5,11 @@ ITEM.WeaponClass = 'weapon_ar2'
 ITEM.SingleUse = true
 
 function ITEM:OnBuy(ply)
-	ply:Give(self.WeaponClass)
+	if (!ply:HasWeapon(self.WeaponClass)) then
+	   ply:Give(self.WeaponClass)
+    else
+        ply:GiveAmmo(60, "AR2", false)
+    end
 	ply:SelectWeapon(self.WeaponClass)
 end
 

--- a/lua/pointshop/items/weapons/crossbow.lua
+++ b/lua/pointshop/items/weapons/crossbow.lua
@@ -5,7 +5,11 @@ ITEM.WeaponClass = 'weapon_crossbow'
 ITEM.SingleUse = true
 
 function ITEM:OnBuy(ply)
-	ply:Give(self.WeaponClass)
+    if (!ply:HasWeapon(self.WeaponClass)) then
+        ply:Give(self.WeaponClass)
+    else
+        ply:GiveAmmo(5, "XBowBolt", false)
+    end
 	ply:SelectWeapon(self.WeaponClass)
 end
 

--- a/lua/pointshop/items/weapons/grenade.lua
+++ b/lua/pointshop/items/weapons/grenade.lua
@@ -5,7 +5,11 @@ ITEM.WeaponClass = 'weapon_frag'
 ITEM.SingleUse = true
 
 function ITEM:OnBuy(ply)
-	ply:Give(self.WeaponClass)
+    if (!ply:HasWeapon(self.WeaponClass)) then
+        ply:Give(self.WeaponClass)
+    else
+        ply:GiveAmmo(1, "Grenade", false)
+    end
 	ply:SelectWeapon(self.WeaponClass)
 end
 

--- a/lua/pointshop/items/weapons/pistol.lua
+++ b/lua/pointshop/items/weapons/pistol.lua
@@ -5,7 +5,11 @@ ITEM.WeaponClass = 'weapon_pistol'
 ITEM.SingleUse = true
 
 function ITEM:OnBuy(ply)
-	ply:Give(self.WeaponClass)
+    if (!ply:HasWeapon(self.WeaponClass)) then
+	   ply:Give(self.WeaponClass)
+    else
+        ply:GiveAmmo(18, "Pistol", false)
+    end
 	ply:SelectWeapon(self.WeaponClass)
 end
 

--- a/lua/pointshop/items/weapons/rpg.lua
+++ b/lua/pointshop/items/weapons/rpg.lua
@@ -5,7 +5,11 @@ ITEM.WeaponClass = 'weapon_rpg'
 ITEM.SingleUse = true
 
 function ITEM:OnBuy(ply)
-	ply:Give(self.WeaponClass)
+    if (!ply:HasWeapon(self.WeaponClass)) then
+	   ply:Give(self.WeaponClass)
+    else
+        ply:GiveAmmo(3, "RPG_Round", false)
+    end
 	ply:SelectWeapon(self.WeaponClass)
 end
 

--- a/lua/pointshop/items/weapons/shotgun.lua
+++ b/lua/pointshop/items/weapons/shotgun.lua
@@ -5,7 +5,11 @@ ITEM.WeaponClass = 'weapon_shotgun'
 ITEM.SingleUse = true
 
 function ITEM:OnBuy(ply)
+    if (!ply:HasWeapon(self.WeaponClass)) then
 	ply:Give(self.WeaponClass)
+    else
+        ply:GiveAmmo(70, "Buckshot", false)
+    end
 	ply:SelectWeapon(self.WeaponClass)
 end
 

--- a/lua/pointshop/items/weapons/smg.lua
+++ b/lua/pointshop/items/weapons/smg.lua
@@ -5,7 +5,11 @@ ITEM.WeaponClass = 'weapon_smg1'
 ITEM.SingleUse = true
 
 function ITEM:OnBuy(ply)
+    if (!ply:HasWeapon(self.WeaponClass)) then
 	ply:Give(self.WeaponClass)
+    else
+        ply:GiveAmmo(180, "SMG1", false)
+    end
 	ply:SelectWeapon(self.WeaponClass)
 end
 

--- a/lua/pointshop/vgui/DPointShopItem.lua
+++ b/lua/pointshop/vgui/DPointShopItem.lua
@@ -3,6 +3,8 @@ local PANEL = {}
 local adminicon = Material("icon16/shield.png")
 local equippedicon = Material("icon16/eye.png")
 local groupicon = Material("icon16/group.png")
+local modifyicon = Material("icon16/color_wheel.png")
+local bodygroupicon = Material("icon16/cog.png")
 
 local canbuycolor = Color(0, 100, 0, 125)
 local cantbuycolor = Color(100, 0, 0, 125)
@@ -56,6 +58,14 @@ function PANEL:DoClick()
 			
 			menu:AddOption('Modify...', function()
 				PS.Items[self.Data.ID]:Modify(LocalPlayer().PS_Items[self.Data.ID].Modifiers)
+			end)
+		end
+        
+        if LocalPlayer():PS_HasItemEquipped(self.Data.ID) and self.Data.BodyGroup then
+			menu:AddSpacer()
+			
+			menu:AddOption('Body Groups...', function()
+                    PS.Items[self.Data.ID]:BodyGroup(LocalPlayer().PS_Items[self.Data.ID].Modifiers)
 			end)
 		end
 	end
@@ -155,6 +165,18 @@ function PANEL:PaintOver()
 		surface.SetDrawColor(Color(255, 255, 255, 255))
 		surface.DrawTexturedRect(5, self:GetTall() - self.InfoHeight - 5 - 16, 16, 16)
 	end
+    
+    if self.Data.Modify then
+		surface.SetMaterial(modifyicon)
+		surface.SetDrawColor(Color(255, 255, 255, 255))
+		surface.DrawTexturedRect(5, 5, 16, 16)
+	end
+    
+    if self.Data.BodyGroup then
+        surface.SetMaterial(bodygroupicon)
+		surface.SetDrawColor(Color(255, 255, 255, 255))
+		surface.DrawTexturedRect(5, 26, 16, 16)
+    end
 	
 	local points = PS.Config.CalculateBuyPrice(LocalPlayer(), self.Data)
 	

--- a/lua/pointshop/vgui/DPointShopPreview.lua
+++ b/lua/pointshop/vgui/DPointShopPreview.lua
@@ -2,7 +2,7 @@ local PANEL = {}
 
 function PANEL:Init()
 	self:SetModel(LocalPlayer():GetModel())
-	
+
 	local PrevMins, PrevMaxs = self.Entity:GetRenderBounds()
 	self:SetCamPos(PrevMins:Distance(PrevMaxs) * Vector(0.30, 0.30, 0.25) + Vector(0, 0, 15))
 	self:SetLookAt((PrevMaxs + PrevMins) / 2)
@@ -14,8 +14,18 @@ function PANEL:Paint()
 	local x, y = self:LocalToScreen( 0, 0 )
 
 	self:LayoutEntity( self.Entity )
-
-	local ang = self.aLookAngle
+    function self.Entity:GetPlayerColor() return LocalPlayer():GetPlayerColor() end
+    
+    self.Entity:SetSkin(LocalPlayer():GetSkin())
+    for i = 0, 20 do
+        if LocalPlayer():GetBodygroup(i) ~= nil then
+            self.Entity:SetBodygroup(i, LocalPlayer():GetBodygroup(i))
+        else
+            self.Entity:SetBodygroup(i, 0)
+        end
+    end
+	
+    local ang = self.aLookAngle
 	if ( !ang ) then
 		ang = (self.vLookatPos-self.vCamPos):Angle()
 	end


### PR DESCRIPTION
- Added check if user owns a weapon, then gives ammo if they do
- Added settings for preset BodyGroup and Skin settings.
To use:
1. Add `ITEM:BodyGroup(modifications)` function to ITEM (Replace "Preset x" with name of the preset in DERMA)
```
function ITEM:BodyGroup(modifications)
    Derma_Query("Choose BodyGroup", "",
        "Preset 1", function()
            modifications.group = 0
            PS:SendModifications(self.ID, modifications)
        end,
        "Preset 2", function()
            modifications.group = 1
            PS:SendModifications(self.ID, modifications)
        end,
        "Preset 3", function()
            modifications.group = 2
            PS:SendModifications(self.ID, modifications)
        end,
        "Preset 4", function()
            modifications.group = 3
            PS:SendModifications(self.ID, modifications)
        end
    )
end
```
2. Add functionality to `ITEM:OnEquip(modifications)` function. If Playermodel supports skins you can apply them too.
Example:
```
function ITEM:OnEquip(ply, modifications)
    if not ply._OldModel then
        ply._OldModel = ply:GetModel()
    end
    timer.Simple(1, function() ply:SetModel(self.Model) end)
    if modifications.group ~= nil then
        if modifications.group == 0 then
            ply:SetSkin(0)
            ply:SetBodygroup(2,0)
        elseif modifications.group == 1 then
            ply:SetSkin(0)
            ply:SetBodygroup(2,1)
        elseif modifications.group == 2 then
            ply:SetSkin(1)
            ply:SetBodygroup(2,2)
        elseif modifications.group == 3 then
            ply:SetSkin(1)
            ply:SetBodygroup(2,3)
        end
    end
end
```
3. (OPTIONAL) Reset player BodyGroups and Skins to default - not doing this caused issues for Prop Hunt when players switched teams and respawned.
```
function ITEM:OnHolster(ply)
    ply:SetSkin(0)
    ply:SetBodygroup(2,0)
	if ply._OldModel then
		ply:SetModel(ply._OldModel)
	end
end
```
- Added playermodel colors (using modifications.color caused issues when I wrote this ~2 years ago). This was written to iverwrite team color being used for the model color on compatible models.
1. Add following code to function "ITEM:Modify"
```
function ITEM:Modify(modifications)
	PS:ShowPlyColorChooser(self, modifications)
end
```
2. Add code to set player's color to it.
```
function ITEM:OnEquip(ply, modifications)
    if not ply._OldModel then
        ply._OldModel = ply:GetModel()
    endle(1, function() ply:SetModel(self.Model) end)
    if modifications.plycolor ~= nil then
        local c = modifications.plycolor
        local r = c["r"]/255
        local g = c["g"]/255
        local b = c["b"]/255
        ply:SetPlayerColor( Vector(r, g, b) )
    end
end
```
- PointShop preview panel automatically updates to the BodyGroups, Skins and Colors.
- I used preset options in DERMA queries instead of sliders for each BodyGroup (like you see in Sandbox) because some PlayerModels (mostly the vocaloids) could be set with unforeseen options like back of head missing or nsfw.