### PR TITLE
Fix "Tried to look up command thirdperson as if it were a variable."

### DIFF
--- a/lua/pointshop/cl_init.lua
+++ b/lua/pointshop/cl_init.lua
@@ -156,7 +156,7 @@ end)
 
 hook.Add('PostPlayerDraw', 'PS_PostPlayerDraw', function(ply)
 	if not ply:Alive() then return end
-	if ply == LocalPlayer() and GetViewEntity():GetClass() == 'player' and (GetConVar('thirdperson') and GetConVar('thirdperson'):GetInt() == 0) then return end
+	if ply == LocalPlayer() and GetViewEntity():GetClass() == 'player' and not ply:ShouldDrawLocalPlayer() then return end
 	if not PS.ClientsideModels[ply] then return end
 	
 	for item_id, model in pairs(PS.ClientsideModels[ply]) do


### PR DESCRIPTION
Change `(GetConVar('thirdperson') and GetConVar('thirdperson'):GetInt() == 0)` to `not ply:ShouldDrawLocalPlayer()`

This fixes console spam when in thirdperson. Although mostly an annoyance, it does appear to cause odd behavior with other addons(?)

I believe this should also fix an occasional playermodel lighting bug some people experience but have been unable to reproduce to test. 